### PR TITLE
fix: playwright install on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint
         run: pnpm biome ci .
       - name: Install playwright
-        run: pnpx playwright@1.45.1 install chromium
+        run: pnpx playwright install chromium
       - name: Test
         run: pnpm test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Lint
         run: pnpm biome ci .
       - name: Install playwright
-        run: pnpx playwright install chromium
+        run: pnpx playwright@1.45.1 install chromium
       - name: Test
         run: pnpm test
         env:


### PR DESCRIPTION
- lock `playwright` version in github workflow to be the same version that is defined in `package.json`