### PR TITLE
fix: remove the new line character

### DIFF
--- a/src/rich-text/UmbracoRichText.tsx
+++ b/src/rich-text/UmbracoRichText.tsx
@@ -1,5 +1,5 @@
 import { decode } from "html-entities";
-import React from "react";
+import * as React from "react";
 import {
   type RenderBlockContext,
   type RichTextElementModel,
@@ -106,6 +106,9 @@ function RichTextElement({
     return null;
 
   if (isTextElement(element)) {
+    // Umbraco adds a new line character to the text element between HTML tags. Remove this, so we keep the HTML valid.
+    // This is only for cases where the only thing in the text element is a new line - This would just be added to keep the HTML pretty.
+    if (element.text === "\n") return null;
     // Decode HTML entities in text nodes
     return decode(element.text);
   }


### PR DESCRIPTION
This pull request makes two changes to the `src/rich-text/UmbracoRichText.tsx` file to improve compatibility and ensure valid HTML rendering by handling unnecessary new line characters in text elements.

### HTML Rendering Fix:
* Added logic to handle cases where the `text` property of a text element contains only a new line character (`"\n"`). These characters, added for HTML formatting, are now ignored to maintain valid HTML. (`[src/rich-text/UmbracoRichText.tsxR109-R111](diffhunk://#diff-5ef3d4f16188bde5a71c54a477792edbd116b0deab53c6aa138d007815af3f1fR109-R111)`)

Library fix for this issue:
https://github.com/umbraco/Umbraco-CMS/issues/19388