### PR TITLE
feat: add stripStyles option to remove inline styles from HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ it with React.
   These will be used, unless the element already has the attribute set. The only
   exception is the `className` attribute, which will be merged with the default
   value.
+- `stripStyles`: Remove inline style attributes from HTML elements. Accepts:
+  - `true`: Removes all inline styles from all HTML elements
+  - An object with configuration options:
+    - `tags`: Array of HTML tags from which to strip styles. If not provided,
+      styles are stripped from all tags.
+    - `except`: Array of HTML tags that should keep their styles, even if they
+      are in the `tags` array.
+  - Default is `false` (all inline styles are preserved).
 
 When passing the `renderBlock` and `renderNode` props, consider making them
 static functions (move them outside the consuming component) to avoid
@@ -78,7 +86,11 @@ function RichText({ data }) {
       data={data.richText}
       renderNode={renderNode}
       renderBlock={renderBlock}
-      htmlAttributes={{ p: { className: "mb-4" }}
+      htmlAttributes={{ p: { className: "mb-4" } }}
+      stripStyles={{
+        // Strip styles from all tags except the following:
+        except: ["img"], // Keep styles on `img` tags
+      }}
     />
   );
 }

--- a/src/rich-text/UmbracoRichText.tsx
+++ b/src/rich-text/UmbracoRichText.tsx
@@ -69,6 +69,20 @@ interface RichTextProps {
   htmlAttributes?: Partial<{
     [Tag in keyof React.JSX.IntrinsicElements]: React.JSX.IntrinsicElements[Tag];
   }>;
+  /**
+   * Strip the inline style attributes from the HTML elements
+   * This can be a boolean to strip all styles, or an object to specify which tags to strip styles from.
+   * If an object is provided, the `tags` property lists tags to strip styles from. If not set, all tags will have their styles stripped.
+   * The `except` property can be used to specify tags that should not have their styles stripped, even if they are in the `tags` array.
+   *
+   * @default false
+   */
+  stripStyles?:
+    | boolean
+    | {
+        tags?: Array<keyof React.JSX.IntrinsicElements>;
+        except?: Array<keyof React.JSX.IntrinsicElements>;
+      };
 }
 
 function parseUrl(href: string) {
@@ -94,12 +108,16 @@ function RichTextElement({
   renderBlock,
   renderNode,
   htmlAttributes = {},
+  stripStyles = false,
   meta,
 }: {
   element: RichTextElementModel;
   blocks: Array<RenderBlockContext> | undefined;
   meta: NodeMeta | undefined;
-} & Pick<RichTextProps, "renderBlock" | "renderNode" | "htmlAttributes">) {
+} & Pick<
+  RichTextProps,
+  "renderBlock" | "renderNode" | "htmlAttributes" | "stripStyles"
+>) {
   if (!element || element.tag === "#comment" || element.tag === "#root")
     return null;
 
@@ -136,6 +154,7 @@ function RichTextElement({
         blocks={blocks}
         renderBlock={renderBlock}
         renderNode={renderNode}
+        stripStyles={stripStyles}
         meta={{
           ancestor: element,
           children: hasElements(node) ? node.elements : undefined,
@@ -189,8 +208,32 @@ function RichTextElement({
       }
     }
 
+    // Handle style attributes
     if (typeof style === "string") {
-      attributes.style = parseStyle(style);
+      // Determine if we should strip styles for this element
+      let shouldStripStyle = stripStyles === true;
+
+      if (typeof stripStyles === "object") {
+        // If tags array is provided, only strip styles from those tags
+        // If tags is not provided, strip from all tags
+        const shouldStrip =
+          stripStyles.tags?.includes(
+            element.tag as keyof React.JSX.IntrinsicElements,
+          ) ?? true;
+
+        // Check if this tag is in the except list
+        const isExcepted =
+          stripStyles.except?.includes(
+            element.tag as keyof React.JSX.IntrinsicElements,
+          ) || false;
+
+        shouldStripStyle = shouldStrip && !isExcepted;
+      }
+
+      // Only parse and add style if we're not stripping it
+      if (!shouldStripStyle) {
+        attributes.style = parseStyle(style);
+      }
     }
 
     if (renderNode) {
@@ -250,6 +293,7 @@ export function UmbracoRichText(props: RichTextProps) {
             renderBlock={props.renderBlock}
             renderNode={props.renderNode}
             htmlAttributes={props.htmlAttributes}
+            stripStyles={props.stripStyles}
             meta={{
               ancestor: rootElement,
               children: hasElements(element) ? element.elements : undefined,

--- a/src/rich-text/UmbracoRichText.tsx
+++ b/src/rich-text/UmbracoRichText.tsx
@@ -211,7 +211,7 @@ function RichTextElement({
     // Handle style attributes
     if (typeof style === "string") {
       // Determine if we should strip styles for this element
-      let shouldStripStyle = stripStyles === true;
+      let shouldStripStyles = stripStyles === true;
 
       if (typeof stripStyles === "object") {
         // If tags array is provided, only strip styles from those tags
@@ -227,11 +227,11 @@ function RichTextElement({
             element.tag as keyof React.JSX.IntrinsicElements,
           ) || false;
 
-        shouldStripStyle = shouldStrip && !isExcepted;
+        shouldStripStyles = shouldStrip && !isExcepted;
       }
 
       // Only parse and add style if we're not stripping it
-      if (!shouldStripStyle) {
+      if (!shouldStripStyles) {
         attributes.style = parseStyle(style);
       }
     }


### PR DESCRIPTION
This pull request introduces a new feature to the `UmbracoRichText` component that allows developers to strip inline style attributes from rendered HTML elements, with flexible configuration options. 

This allows you to handle the cases where Umbraco might output inline styles, after content has been pasted into the Rich Text field.

### Feature addition: Strip inline styles

* Added a new `stripStyles` prop to the `UmbracoRichText` component, allowing consumers to remove inline style attributes from HTML elements. This prop accepts a boolean or a configuration object to specify which tags to strip styles from or to exclude certain tags.
* Implemented the logic in `UmbracoRichText.tsx` to handle the `stripStyles` prop, determining whether to strip styles based on the provided configuration (all tags, specific tags, or exceptions).
* Updated the README documentation to describe the new `stripStyles` prop, its options, and usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R35-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R93)

### Testing and integration

* Added comprehensive tests to verify that inline styles are correctly stripped according to the `stripStyles` prop, including cases for all tags, specific tags, exceptions, and combinations thereof.